### PR TITLE
Fix typo sequencerClient.js

### DIFF
--- a/sequencerclient/sequencerClient.js
+++ b/sequencerclient/sequencerClient.js
@@ -86,7 +86,7 @@ class Sequencer {
         } catch (err) {
             logger.error('contribute err', err);
             return {
-                status: err.resposne.status,
+                status: err.response.status,
                 msg: err.response.data.error,
             }
         }


### PR DESCRIPTION
Sending the contribution failed with:

    [ info ] Send contributions
    [ error ] contribute err Request failed with status code 400
    /host/sequencerclient/sequencerClient.js:89
                    status: err.resposne.status,
                                         ^

    TypeError: Cannot read properties of undefined (reading 'status')
        at Sequencer.contribute (/git/sequencerclient/sequencerClient.js:89:38)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async send_contribute (/host/index.js:172:21)
        at async Command.<anonymous> (/host/index.js:55:25)

Not being able to display the error message was due to using `err.resposne` instead o`f err.response`.